### PR TITLE
Compute various stats

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,19 @@
+
+var memjs = require('memjs');
+
+
+function getClient() {
+  return memjs.Client.create();
+}
+
+exports.set = function(key, item, callback, expiration) {
+  var client = getClient();
+
+  client.set(key, JSON.stringify(item), callback, expiration);
+}
+
+exports.get = function(key, callback) {
+  var client = getClient();
+
+  client.get(key, callback);
+}

--- a/github.js
+++ b/github.js
@@ -26,13 +26,16 @@ var request = function (path) {
 
 var getProjectIssueCount = function(project, urlProperty) {
   var name = project.name;
-  var url = project[urlProperty];
+  var url = project.counts[urlProperty];
+  return getProjectCount(name, url, urlProperty);
+}
 
-  console.log("Fetching issue count (" + urlProperty + ") for project: \'" + name + "\'...");
+var getProjectCount = function(name, url, key) {
+  console.log("Fetching issue count (" + key + ") for project: \'" + name + "\'...");
 
   return request(url)
-    .select(function(issues) {
-        return { 'project': name, 'count': issues.length, 'type': urlProperty };
+    .select(function(items) {
+        return { 'project': name, 'count': items.length, 'type': key };
     });
 }
 
@@ -40,34 +43,52 @@ var computeIssueCounts = function(projects, urlProperty) {
   return Rx.Observable.from(projects)
     .take(2)
     .select(function (project) {
-
-      var name = project[0];
-      var url = project[1][urlProperty];
-
-      console.log("Fetching issue count (" + urlProperty + ") for project: \'" + name + "\'...")
-
-      return request(url)
-        .select(function(issues) {
-            return { 'project': name, 'count': issues.length, 'type': urlProperty };
-        });
+      return getProjectIssueCount(project[1], urlProperty);
     })
     .mergeAll();
 }
 
+var getProjectStats = function(project, initialiser) {
+  initialiser = initialiser || {};
+
+  var name = project.name;
+
+  console.log('Getting stats for ' + name)
+
+  var countObservables = Object.keys(project.counts)
+          .map(function(key) {
+            var url = project.counts[key];
+            console.log(key + " " + url);
+            return getProjectCount(name, url, key)
+          });
+
+  var counts = Rx.Observable.merge(countObservables);
+
+  return counts.reduce(function (result, stat, i, source) {
+    result[stat.type] = stat.count;
+    return result;
+  }, initialiser);
+};
+
 exports.request = request;
 
-exports.getProjectOpenIssueCount = function(project) {
-  return getProjectIssueCount(project, "openIssueCount");
+exports.getProjectStats = function(project, success, error) {
+  getProjectStats(project).subscribe(success, error);
 }
 
-exports.getProjectClosedIssueCount = function(project) {
-  return getProjectIssueCount(project, "closedIssueCount");
-}
-
-exports.computeOpenIssueCounts = function(projects) {
-  return computeIssueCounts(projects, "openIssueCount");
-}
-
-exports.computeClosedIssueCounts = function(projects) {
-  return computeIssueCounts(projects, "closedIssueCount");
+exports.computeStats = function(projects, success, error) {
+  var statObservers = Rx.Observable.from(projects)
+    .take(2)
+    .select(function(projectEntry) {
+      var project = projectEntry[1];
+      return getProjectStats(project, { name: project.name });
+    })
+    .mergeAll()
+    .reduce(function (result, stat, i, source) {
+      var name = stat.name;
+      stat.name = undefined;
+      result[name] = stat;
+      return result;
+    }, {})
+    .subscribe(success, error);
 }

--- a/github.js
+++ b/github.js
@@ -30,12 +30,6 @@ var request = function (uri) {
   return Rx.Observable.fromPromise(promise);
 };
 
-var getProjectIssueCount = function(project, urlProperty) {
-  var name = project.name;
-  var url = project.counts[urlProperty];
-  return getProjectCount(name, url, urlProperty);
-}
-
 var getProjectCount = function(name, path, key) {
   console.log("Fetching issue count (" + key + ") for project: \'" + name + "\'...");
 
@@ -56,15 +50,6 @@ var getProjectCount = function(name, path, key) {
         return Rx.Observable.fromPromise(
           Promise.resolve({ 'project': name, 'count': response.body.length, 'type': key })
         );
-    })
-    .mergeAll();
-}
-
-var computeIssueCounts = function(projects, urlProperty) {
-  return Rx.Observable.from(projects)
-    .take(2)
-    .select(function (project) {
-      return getProjectIssueCount(project[1], urlProperty);
     })
     .mergeAll();
 }

--- a/github.js
+++ b/github.js
@@ -24,6 +24,18 @@ var request = function (path) {
   return Rx.Observable.fromPromise(promise);
 };
 
+var getProjectIssueCount = function(project, urlProperty) {
+  var name = project.name;
+  var url = project[urlProperty];
+
+  console.log("Fetching issue count (" + urlProperty + ") for project: \'" + name + "\'...");
+
+  return request(url)
+    .select(function(issues) {
+        return { 'project': name, 'count': issues.length, 'type': urlProperty };
+    });
+}
+
 var computeIssueCounts = function(projects, urlProperty) {
   return Rx.Observable.from(projects)
     .take(2)
@@ -36,13 +48,21 @@ var computeIssueCounts = function(projects, urlProperty) {
 
       return request(url)
         .select(function(issues) {
-            return { 'project': name, 'count': issues.length }
+            return { 'project': name, 'count': issues.length, 'type': urlProperty };
         });
     })
     .mergeAll();
 }
 
 exports.request = request;
+
+exports.getProjectOpenIssueCount = function(project) {
+  return getProjectIssueCount(project, "openIssueCount");
+}
+
+exports.getProjectClosedIssueCount = function(project) {
+  return getProjectIssueCount(project, "closedIssueCount");
+}
 
 exports.computeOpenIssueCounts = function(projects) {
   return computeIssueCounts(projects, "openIssueCount");

--- a/github.js
+++ b/github.js
@@ -24,18 +24,15 @@ var request = function (path) {
   return Rx.Observable.fromPromise(promise);
 };
 
-exports.request = request;
-
-exports.computeIssueCounts = function(projects) {
-
+var computeIssueCounts = function(projects, urlProperty) {
   return Rx.Observable.from(projects)
     .take(2)
     .select(function (project) {
 
       var name = project[0];
-      var url = project[1].issueCount;
+      var url = project[1][urlProperty];
 
-      console.log("Fetching issue count for project: \'" + name + "\'...")
+      console.log("Fetching issue count (" + urlProperty + ") for project: \'" + name + "\'...")
 
       return request(url)
         .select(function(issues) {
@@ -43,4 +40,14 @@ exports.computeIssueCounts = function(projects) {
         });
     })
     .mergeAll();
+}
+
+exports.request = request;
+
+exports.computeOpenIssueCounts = function(projects) {
+  return computeIssueCounts(projects, "openIssueCount");
+}
+
+exports.computeClosedIssueCounts = function(projects) {
+  return computeIssueCounts(projects, "closedIssueCount");
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var express = require('express')
 var bodyParser = require('body-parser')
 var Rx = require('rx');
 var cache = require('./cache.js')
-var issueCounts = require('./issue-counts.js')
+var stats = require('./stats.js')
 
 if (process.env.GITHUB_TOKEN == null) {
   console.warn("No GITHUB_TOKEN environment variable set, unauthenticated access is very limited...");
@@ -45,7 +45,7 @@ app.get('/refresh', function(request, response) {
     return;
   }
 
-  issueCounts.refresh(dict, function (err) {
+  stats.refresh(dict, function (err) {
     console.log('Error found in response');
     console.log('Status Code: ' + err.statusCode);
     console.log('Response: ' + err.response.body);
@@ -66,7 +66,7 @@ app.get('/issues/count', function(request, response) {
   if (projectName == null)
   {
     // no project specified -> return all results
-    issueCounts.getAll(function(msg) {
+    stats.getAll(function(msg) {
       response.status(500).send(msg);
     }, function() {
       response.status(204).send();
@@ -84,7 +84,7 @@ app.get('/issues/count', function(request, response) {
      return;
   }
 
-  issueCounts.getProject(projectJson, function(msg) {
+  stats.getProject(projectJson, function(msg) {
     response.status(500).send(msg);
   }, function(result) {
     response.send(result);

--- a/index.js
+++ b/index.js
@@ -45,12 +45,8 @@ app.get('/refresh', function(request, response) {
     return;
   }
 
-  stats.refresh(dict, function (err) {
-    console.log('Error found in response');
-    console.log('Status Code: ' + err.statusCode);
-    console.log('Response: ' + err.response.body);
-
-    response.status(500).send("something happened");
+  stats.refresh(dict, function (msg) {
+    response.status(500).send(msg);
   }, function(counts) {
     response.send(counts);
   });
@@ -70,8 +66,8 @@ app.get('/issues/count', function(request, response) {
       response.status(500).send(msg);
     }, function() {
       response.status(204).send();
-    }, function(json) {
-      response.send(json);
+    }, function(projects) {
+      response.send({ projects: projects });
     });
     return;
   }

--- a/issue-counts.js
+++ b/issue-counts.js
@@ -1,0 +1,103 @@
+
+var cache = require('./cache.js')
+var github = require('./github.js')
+
+var expiration = 600; // 10 minutes
+
+var OPEN_ISSUE_COUNT_ALL_KEY = "issue-count-open-all";
+var OPEN_ISSUE_COUNT_PROJECT_PREFIX = "issue-count-open-";
+
+exports.getProject = function(project, error, success) {
+
+    var key = OPEN_ISSUE_COUNT_PROJECT_PREFIX + project.name;
+
+    cache.get(key, function(err, val) {
+      if (err != null) {
+        console.log(err);
+        error('Unable to connect to database');
+      }
+
+      var isCached = err == null && val != null;
+
+      if (!isCached) {
+        console.log("value for \'" + key + "\' not cached");
+
+        github
+          .request(project.openIssueCount)
+          .subscribe(
+            function (issues) {
+              var count = issues.length;
+
+              cache.set(key, count, function(err, val) {
+                if (err != null) {
+                  console.log(err);
+                }
+
+                console.log("stored value: \'" + key + "\' - \'" + val.toString() + "\'");
+
+                success({ cached: false, openIssueCount: count });
+              }, expiration);
+
+            },
+            function (err) {
+              console.log('Error found in response');
+              console.log('Status Code: ' + err.statusCode);
+              console.log('Response: ' + err.response.body);
+              error("something happened");
+            }
+        );
+      } else {
+        var str = val.toString();
+        var count = parseInt(str);
+
+        console.log("value for \'" + key + "\' cached - got \'" + str + "\'");
+        success({ cached: isCached, openIssueCount: count });
+      }
+    });
+}
+
+exports.getAll = function(error, cacheMiss, success) {
+  // no project specified -> return all results
+  cache.get(OPEN_ISSUE_COUNT_ALL_KEY, function(err, val) {
+    if (err != null) {
+       console.log(err);
+       error('Unable to connect to store');
+    }
+
+    if(!val) {
+      cacheMiss();
+      return;
+    }
+
+     var text = val.toString();
+     var json = JSON.parse(text);
+
+     success(json);
+    });
+
+}
+
+exports.refresh = function(projects, error, success) {
+  var array = { };
+
+  github
+    .computeOpenIssueCounts(projects)
+    .subscribe(
+      function (map) {
+        array[map.project] = map.count;
+      },
+      error,
+      function () {
+          console.log('Completed, storing in memcached');
+
+          cache.set(OPEN_ISSUE_COUNT_ALL_KEY, array, function(err, val) {
+            if (err != null) {
+              console.log(err);
+            }
+
+            success({ openIssueCounts: array });
+
+          }, expiration);
+      }
+    );
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "body-parser": "^1.14.2",
     "express": "^4.13.3",
     "memjs": "^0.8.9",
+    "parse-link-header": "^0.4.1",
+    "promise": "^7.1.1",
     "request-promise": "^1.0.2",
     "rx": "^4.0.7",
     "yamljs": "^0.2.4"

--- a/projects.js
+++ b/projects.js
@@ -26,17 +26,20 @@ exports.setup = function () {
       var repo = values[2];
       var labelEncoded = encodeURI(label);
 
-      var issueCountUrl = "/repos/" + owner + "/" + repo + "/issues?labels=" + labelEncoded + "&per_page=100";
+      var repoUrl = "/repos/" + owner + "/" + repo;
+      var issueCountUrl = repoUrl + "/issues?labels=" + labelEncoded + "&per_page=100";
       var closedIssueCountUrl = issueCountUrl + "&state=closed"
       var openIssueCountUrl = issueCountUrl + "&state=open";
 
-      var contributorsUrl = "/repos/:owner/:repo/stats/contributors";
+      var contributorsCountUrl = repoUrl + "/stats/contributors";
 
       var obj = {
-        "name": nativeObject.name,
-        "closedIssueCount": closedIssueCountUrl,
-        "openIssueCount": openIssueCountUrl,
-        "contributors": contributorsUrl
+        name: nativeObject.name,
+        counts: {
+          closedIssueCount: closedIssueCountUrl,
+          openIssueCount: openIssueCountUrl,
+          contributorsCount: contributorsCountUrl
+        }
       };
 
       dict.set(nativeObject.name, obj);

--- a/projects.js
+++ b/projects.js
@@ -27,10 +27,17 @@ exports.setup = function () {
       var labelEncoded = encodeURI(label);
 
       var issueCountUrl = "/repos/" + owner + "/" + repo + "/issues?labels=" + labelEncoded + "&per_page=100";
+      var closedIssueCountUrl = issueCountUrl + "&state=closed"
+      var openIssueCountUrl = issueCountUrl + "&state=open";
 
-      // TODO: attach some other properties here
+      var contributorsUrl = "/repos/:owner/:repo/stats/contributors";
 
-      var obj = { "issueCount": issueCountUrl };
+      var obj = {
+        "name": nativeObject.name,
+        "closedIssueCount": closedIssueCountUrl,
+        "openIssueCount": openIssueCountUrl,
+        "contributors": contributorsUrl
+      };
 
       dict.set(nativeObject.name, obj);
     } else {

--- a/stats.js
+++ b/stats.js
@@ -22,26 +22,26 @@ exports.getProject = function(project, error, success) {
       if (!isCached) {
         console.log("value for \'" + key + "\' not cached");
 
-        var issueCounts = Rx.Observable.merge(
+        var stats = Rx.Observable.merge(
           github.getProjectOpenIssueCount(project),
           github.getProjectClosedIssueCount(project)
         );
 
-        issueCounts
+        stats
           .reduce(function (result, stat, i, source) {
             result[stat.type] = stat.count;
             return result;
           }, {})
           .subscribe(
-            function (stats) {
-              cache.set(key, stats, function(err, val) {
+            function (results) {
+              cache.set(key, results, function(err, val) {
                 if (err != null) {
                   console.log(err);
                 }
 
-                console.log("stored value: \'" + key + "\' - \'" + JSON.stringify(stats) + "\'");
+                console.log("stored value: \'" + key + "\' - \'" + JSON.stringify(results) + "\'");
 
-                success({ cached: false, stats: stats });
+                success({ cached: false, stats: results });
               }, expiration);
 
             },
@@ -84,12 +84,12 @@ exports.getAll = function(error, cacheMiss, success) {
 }
 
 exports.refresh = function(projects, error, success) {
-  var issueCounts = Rx.Observable.merge(
+  var stats = Rx.Observable.merge(
     github.computeOpenIssueCounts(projects),
     github.computeClosedIssueCounts(projects)
   );
 
-  issueCounts
+  stats
     .reduce(function (results, stat, i, source) {
       var project = results[stat.project];
       if(!project) {


### PR DESCRIPTION
The main changes I have made are to split the index.js script up a little bit and make the computation of counts more generic.
- index.js - only handles requests
- stats.js - gets stats (from cache or computes them)
- github.js - makes requests to get stats

These changes means that to add another count, a url just has to be added to the definition in projects.js. It can now also count over the per_page limit by making a second request to the last link, counting the items on that page and making a calculation based of (X pages - 1) x Y page size + count on last page.

Would resolve #5 
